### PR TITLE
Fix discussion board link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Travel with us around the world as we apply these classic techniques to data fro
 - Take the post-lecture quiz
 - Complete the challenge
 - Complete the assignment
-- After completing a lesson group, visit the [Discussion board](/discussions) and "learn out loud" by filling out the appropriate PAT rubric. A 'PAT' is a Progress Assessment Tool that is a rubric you fill out to further your learning. You can also react to other PATs so we can learn together.
+- After completing a lesson group, visit the [Discussion board](https://github.com/microsoft/ML-For-Beginners/discussions) and "learn out loud" by filling out the appropriate PAT rubric. A 'PAT' is a Progress Assessment Tool that is a rubric you fill out to further your learning. You can also react to other PATs so we can learn together.
 
 > For further study, we recommend following these [Microsoft Learn](https://docs.microsoft.com/en-us/users/jenlooper-2911/collections/k7o7tg1gp306q4?WT.mc_id=academic-15963-cxa) modules and learning paths.
 


### PR DESCRIPTION
Very cool course, thanks for sharing it! I noticed that if you click on the Discussion Board link from the README in GitHub, you get a 404. 

<img width="905" alt="Screen Shot 2021-07-01 at 6 01 11 PM" src="https://user-images.githubusercontent.com/97182/124205704-a69a1f00-da96-11eb-9cef-e472883203b5.png">

This PR changes the link to an absolute link, instead of a relative URL, which should fix the problem.