### PR TITLE
Change the pdf link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can run this documentation offline by using [Docsify](https://docsify.js.org
 
 ## PDFs
 
-Find a pdf of the curriculum with links [here](pdf/readme.pdf).
+Find a pdf of the curriculum with links [here](https://microsoft.github.io/ML-For-Beginners/pdf/readme.pdf).
 
 ## Help Wanted!
 


### PR DESCRIPTION
This should fix the #357, Well after experimenting with docsify, even if we move the pdf file to `docs/` folder, the pdf will not render itself and still returns a 404. So instead, I just changed the link to go to the pdf file in microsoft.github.io/ML-For-Beginners/pdf/readme.pdf