### PR TITLE
Fix multiple function calls in Chapter 5

### DIFF
--- a/5-Clustering/1-Visualize/README.md
+++ b/5-Clustering/1-Visualize/README.md
@@ -300,7 +300,7 @@ Are these three genres significantly different in the perception of their dancea
 1. Create a scatter plot:
 
     ```python
-    sns.FacetGrid(df, hue="artist_top_genre", size=5) \
+    sns.FacetGrid(df, hue="artist_top_genre", height=5) \
        .map(plt.scatter, "popularity", "danceability") \
        .add_legend()
     ```

--- a/5-Clustering/1-Visualize/README.md
+++ b/5-Clustering/1-Visualize/README.md
@@ -258,7 +258,7 @@ Note, when the top genre is described as 'Missing', that means that Spotify did 
 1. Do a quick test to see if the data correlates in any particularly strong way:
 
     ```python
-    corrmat = df.corr()
+    corrmat = df.corr(numeric_only=True)
     f, ax = plt.subplots(figsize=(12, 9))
     sns.heatmap(corrmat, vmax=.8, square=True)
     ```

--- a/5-Clustering/2-K-Means/README.md
+++ b/5-Clustering/2-K-Means/README.md
@@ -169,7 +169,7 @@ Previously, you surmised that, because you have targeted 3 song genres, you shou
 
     ```python
     plt.figure(figsize=(10,5))
-    sns.lineplot(range(1, 11), wcss,marker='o',color='red')
+    sns.lineplot(x=range(1, 11), y=wcss, marker='o', color='red')
     plt.title('Elbow')
     plt.xlabel('Number of clusters')
     plt.ylabel('WCSS')


### PR DESCRIPTION
Hello,

there are currently two problems with the README of 5.1:

`df.corr`
The default value of `df.corr()`'s `numeric_only` parameter [changed to False in 2.0](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.corr.html#pandas.DataFrame.corr). 
Therefore the code in the notebook throws an error when executed. 
I set the parameter back to True, which fixes the notebook.

`sns.FacetGrid`
The name of the `size` parameter has changed to `height`.
I fixed that as well.


There is also a change in the handling of sns color palettes, where you now have to assign the `hue` parameter to `x`, but I did not include that change, yet. Let me know, if you would like me to add it.

In the README of 5.2, the `sns.lineplot` function does not accept 2 positional arguments (anymore). I named them `x` and `y` accordingly.

Best regards,
Maik