### PR TITLE
Add Generative AI with Java course to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Our team produces other courses! Check out:
 - [Generative AI for Beginners](https://aka.ms/genai-beginners)
 - [Generative AI for Beginners .NET](https://github.com/microsoft/Generative-AI-for-beginners-dotnet)
 - [Generative AI with JavaScript](https://github.com/microsoft/generative-ai-with-javascript)
+- [Generative AI with Java](https://github.com/microsoft/Generative-AI-for-beginners-java)
 - [AI for Beginners](https://aka.ms/ai-beginners)
 - [Data Science for Beginners](https://aka.ms/datascience-beginners)
 - [ML for Beginners](https://aka.ms/ml-beginners)


### PR DESCRIPTION
Included a link to the 'Generative AI with Java' course in the list of related resources in the README.