### PR TITLE
Fix spacing in Japanese README instructions

### DIFF
--- a/translations/ja/2-Regression/1-Tools/README.md
+++ b/translations/ja/2-Regression/1-Tools/README.md
@@ -53,9 +53,9 @@
 
 ### 演習 - ノートブックを操作する
 
-このフォルダには、_notebook.ipynb_というファイルがあります。
+このフォルダには、_notebook.ipynb_ というファイルがあります。
 
-1. Visual Studio Codeで_notebook.ipynb_を開きます。
+1. Visual Studio Codeで _notebook.ipynb_ を開きます。
 
    JupyterサーバーがPython 3+で起動します。ノートブック内には`run`できるコード部分があります。コードブロックを実行するには、再生ボタンのようなアイコンを選択します。
 
@@ -63,7 +63,7 @@
 
    次に、Pythonコードを追加します。
 
-3. コードブロックに**print('hello notebook')**と入力します。
+3. コードブロックに **print('hello notebook')** と入力します。
 4. 矢印を選択してコードを実行します。
 
    以下の出力が表示されるはずです:


### PR DESCRIPTION
https://github.com/microsoft/ML-For-Beginners/blob/main/translations/ja/2-Regression/1-Tools/README.md 

<img width="768" height="455" alt="image" src="https://github.com/user-attachments/assets/3598ec29-fd92-4ba4-ab56-3dab2b42510a" />

related https://github.com/Azure/co-op-translator/issues/236

#PingMSFTDocs