### PR TITLE
fix: replace dead gym.openai.com links with gymnasium.farama.org

### DIFF
--- a/8-Reinforcement/2-Gym/README.md
+++ b/8-Reinforcement/2-Gym/README.md
@@ -24,9 +24,9 @@ In this lesson, we will be using a library called **OpenAI Gym** to simulate dif
 
 ## OpenAI Gym
 
-In the previous lesson, the rules of the game and the state were given by the `Board` class which we defined ourselves. Here we will use a special **simulation environment**, which will simulate the physics behind the balancing pole. One of the most popular simulation environments for training reinforcement learning algorithms is called a [Gym](https://gym.openai.com/), which is maintained by [OpenAI](https://openai.com/). By using this gym we can create difference **environments** from a cartpole simulation to Atari games.
+In the previous lesson, the rules of the game and the state were given by the `Board` class which we defined ourselves. Here we will use a special **simulation environment**, which will simulate the physics behind the balancing pole. One of the most popular simulation environments for training reinforcement learning algorithms is called a [Gym](https://gymnasium.farama.org/), which is maintained by [OpenAI](https://openai.com/). By using this gym we can create difference **environments** from a cartpole simulation to Atari games.
 
-> **Note**: You can see other environments available from OpenAI Gym [here](https://gym.openai.com/envs/#classic_control). 
+> **Note**: You can see other environments available from OpenAI Gym [here](https://gymnasium.farama.org/environments/classic_control/). 
 
 First, let's install the gym and import required libraries (code block 1):
 

--- a/8-Reinforcement/2-Gym/assignment.md
+++ b/8-Reinforcement/2-Gym/assignment.md
@@ -1,10 +1,10 @@
 # Train Mountain Car
 
-[OpenAI Gym](http://gym.openai.com) has been designed in such a way that all environments provide the same API - i.e. the same methods `reset`, `step` and `render`, and the same abstractions of **action space** and **observation space**. Thus is should be possible to adapt the same reinforcement learning algorithms to different environments with minimal code changes.
+[OpenAI Gym](https://gymnasium.farama.org) has been designed in such a way that all environments provide the same API - i.e. the same methods `reset`, `step` and `render`, and the same abstractions of **action space** and **observation space**. Thus is should be possible to adapt the same reinforcement learning algorithms to different environments with minimal code changes.
 
 ## A Mountain Car Environment
 
-[Mountain Car environment](https://gym.openai.com/envs/MountainCar-v0/) contains a car stuck in a valley:
+[Mountain Car environment](https://gymnasium.farama.org/environments/classic_control/mountain_car/) contains a car stuck in a valley:
 
 <img src="images/mountaincar.png" width="300"/>
 


### PR DESCRIPTION
## Summary
Replaces dead `gym.openai.com` links in the Reinforcement Learning lesson.

OpenAI Gym moved to the Farama Foundation as "Gymnasium" (`gymnasium.farama.org`). The old `gym.openai.com` domain is no longer active.

## Changes
- `8-Reinforcement/2-Gym/README.md`: Updated env links to gymnasium.farama.org
- `8-Reinforcement/2-Gym/assignment.md`: Updated assignment references to new domain

## Testing
- Verified `gymnasium.farama.org` is live and serves documentation