### PR TITLE
Update resource links in Japanese README

### DIFF
--- a/translations/ja/quiz-app/README.md
+++ b/translations/ja/quiz-app/README.md
@@ -109,8 +109,8 @@ jobs:
 ```
 
 ### 追加リソース
-- [Azure Static Web Apps Documentation](https://learn.microsoft.com/azure/static-web-apps/getting-started)  
-- [GitHub Actions Documentation](https://docs.github.com/actions/use-cases-and-examples/deploying/deploying-to-azure-static-web-app)  
+- [Azure Static Web Apps を使用して静的サイトを初めて構築する](https://learn.microsoft.com/azure/static-web-apps/getting-started)  
+- [Azure 静的 Web アプリへのデプロイ](https://docs.github.com/actions/use-cases-and-examples/deploying/deploying-to-azure-static-web-app)  
 
 ---
 


### PR DESCRIPTION
Updated resource links in Japanese README for quiz app. 

https://github.com/microsoft/ML-For-Beginners/blob/main/translations/ja/quiz-app/README.md 

<img width="1174" height="95" alt="image" src="https://github.com/user-attachments/assets/4b64bada-fc50-457f-bc38-bdceb6a8352a" />

related https://github.com/Azure/co-op-translator/issues/230

#PingMSFTDocs