### PR TITLE
fix: replace deprecated pandas as_matrix() with to_numpy()

### DIFF
--- a/7-TimeSeries/1-Introduction/solution/common/utils.py
+++ b/7-TimeSeries/1-Introduction/solution/common/utils.py
@@ -120,13 +120,13 @@ class TimeSeriesTensor(UserDict):
     
         inputs = {}
         y = dataframe['target']
-        y = y.as_matrix()
+        y = y.to_numpy()
         inputs['target'] = y
 
         for name, structure in self.tensor_structure.items():
             rng = structure[0]
             cols = structure[1]
-            tensor = dataframe[name][cols].as_matrix()
+            tensor = dataframe[name][cols].to_numpy()
             if rng is None:
                 tensor = tensor.reshape(tensor.shape[0], len(cols))
             else:

--- a/7-TimeSeries/1-Introduction/working/common/utils.py
+++ b/7-TimeSeries/1-Introduction/working/common/utils.py
@@ -120,13 +120,13 @@ class TimeSeriesTensor(UserDict):
     
         inputs = {}
         y = dataframe['target']
-        y = y.as_matrix()
+        y = y.to_numpy()
         inputs['target'] = y
 
         for name, structure in self.tensor_structure.items():
             rng = structure[0]
             cols = structure[1]
-            tensor = dataframe[name][cols].as_matrix()
+            tensor = dataframe[name][cols].to_numpy()
             if rng is None:
                 tensor = tensor.reshape(tensor.shape[0], len(cols))
             else:

--- a/7-TimeSeries/2-ARIMA/solution/common/utils.py
+++ b/7-TimeSeries/2-ARIMA/solution/common/utils.py
@@ -120,13 +120,13 @@ class TimeSeriesTensor(UserDict):
     
         inputs = {}
         y = dataframe['target']
-        y = y.as_matrix()
+        y = y.to_numpy()
         inputs['target'] = y
 
         for name, structure in self.tensor_structure.items():
             rng = structure[0]
             cols = structure[1]
-            tensor = dataframe[name][cols].as_matrix()
+            tensor = dataframe[name][cols].to_numpy()
             if rng is None:
                 tensor = tensor.reshape(tensor.shape[0], len(cols))
             else:

--- a/7-TimeSeries/2-ARIMA/working/common/utils.py
+++ b/7-TimeSeries/2-ARIMA/working/common/utils.py
@@ -120,13 +120,13 @@ class TimeSeriesTensor(UserDict):
     
         inputs = {}
         y = dataframe['target']
-        y = y.as_matrix()
+        y = y.to_numpy()
         inputs['target'] = y
 
         for name, structure in self.tensor_structure.items():
             rng = structure[0]
             cols = structure[1]
-            tensor = dataframe[name][cols].as_matrix()
+            tensor = dataframe[name][cols].to_numpy()
             if rng is None:
                 tensor = tensor.reshape(tensor.shape[0], len(cols))
             else:

--- a/7-TimeSeries/common/utils.py
+++ b/7-TimeSeries/common/utils.py
@@ -122,13 +122,13 @@ class TimeSeriesTensor(UserDict):
     
         inputs = {}
         y = dataframe['target']
-        y = y.as_matrix()
+        y = y.to_numpy()
         inputs['target'] = y
 
         for name, structure in self.tensor_structure.items():
             rng = structure[0]
             cols = structure[1]
-            tensor = dataframe[name][cols].as_matrix()
+            tensor = dataframe[name][cols].to_numpy()
             if rng is None:
                 tensor = tensor.reshape(tensor.shape[0], len(cols))
             else:


### PR DESCRIPTION
## Description

This PR fixes deprecated pandas API usage in the TimeSeries lessons by replacing `as_matrix()` with `to_numpy()`.

## Changes

- Replace `DataFrame.as_matrix()` with `DataFrame.to_numpy()` in `TimeSeriesTensor._df2tensors()`
- Affected files:
  - `7-TimeSeries/common/utils.py`
  - `7-TimeSeries/1-Introduction/working/common/utils.py`
  - `7-TimeSeries/1-Introduction/solution/common/utils.py`
  - `7-TimeSeries/2-ARIMA/working/common/utils.py`
  - `7-TimeSeries/2-ARIMA/solution/common/utils.py`

## Motivation

`DataFrame.as_matrix()` was deprecated in pandas 0.25.0 and removed in later versions. Students running these lessons with modern pandas encounter `AttributeError: 'DataFrame' object has no attribute 'as_matrix'`.

## Testing

- Verified syntax correctness
- `to_numpy()` is the recommended replacement per pandas documentation
- Maintains backward compatibility with pandas 0.25.0+

## Related Issues

Fixes #1012

---

Note: Local environment limitations, relying on CI/CD automated testing for full validation.
