### PR TITLE
Replace as_matrix() with to_numpy() for compatibility

### DIFF
--- a/7-TimeSeries/1-Introduction/working/common/utils.py
+++ b/7-TimeSeries/1-Introduction/working/common/utils.py
@@ -120,13 +120,13 @@ class TimeSeriesTensor(UserDict):
     
         inputs = {}
         y = dataframe['target']
-        y = y.as_matrix()
+        y = y.to_numpy()
         inputs['target'] = y
 
         for name, structure in self.tensor_structure.items():
             rng = structure[0]
             cols = structure[1]
-            tensor = dataframe[name][cols].as_matrix()
+            tensor = dataframe[name][cols].to_numpy()
             if rng is None:
                 tensor = tensor.reshape(tensor.shape[0], len(cols))
             else:


### PR DESCRIPTION
Replaced all occurrences of .as_matrix()\ with .to_numpy()\ in:

    \7-TimeSeries/common/utils.py\
    \7-TimeSeries/1-Introduction/working/common/utils.py\
    \7-TimeSeries/1-Introduction/solution/common/utils.py\
    \7-TimeSeries/2-ARIMA/working/common/utils.py\
    \7-TimeSeries/2-ARIMA/solution/common/utils.py\
